### PR TITLE
Fix consolidation function setting

### DIFF
--- a/lib/datasources/WeatherMapDataSource_rrd.php
+++ b/lib/datasources/WeatherMapDataSource_rrd.php
@@ -430,7 +430,7 @@ class WeatherMapDataSource_rrd extends WeatherMapDataSource {
             }
         }
 
-        $cfname = intval($map->get_hint('rrd_cf'));
+        $cfname = $map->get_hint('rrd_cf');
         if ($cfname===null) {
             $cfname='AVERAGE';
         }


### PR DESCRIPTION
Hi, the consolidation function setting is broken, the string is converted to an integer so neither the default not the user-set functions are used.