### PR TITLE
ProcessTargets' "Not recognised as a valid TARGET" warning prints processed target string

### DIFF
--- a/lib/Weathermap.class.php
+++ b/lib/Weathermap.class.php
@@ -573,7 +573,7 @@ class WeatherMap extends WeatherMapBase
                                 }
                             }
                             if (!$matched) {
-                                wm_warn("ProcessTargets: $type $name, target: $target[4] on config line $target[3] of $target[2] was not recognised as a valid TARGET [WMWARN08]\n");
+                                wm_warn("ProcessTargets: $type $name, target: $targetString on config line $target[3] of $target[2] was not recognised as a valid TARGET [WMWARN08]\n");
                             }
 
                             $targetIndex++;


### PR DESCRIPTION
Warning text where any tokens have been already substituted is more useful to identify what bit on the target is wrong (e.g. if RRD file, wrong filename).

For example, $target[4]  may contain "{link:this:name}.rrd", whereas $targetString would contain the string after substitution (e.g. "router1-interface-ae0.rrd")