### PR TITLE
V offset

### DIFF
--- a/docs/src/global_fontdefine.xml
+++ b/docs/src/global_fontdefine.xml
@@ -22,6 +22,17 @@
         <meta>fontsize</meta>
     </definition>
 
+    <definition>FONTDEFINE
+
+        <meta>fontnumber</meta>
+
+        <meta>ttffontfile</meta>
+
+        <meta>fontsize</meta>
+
+        <meta>v_offset</meta>
+    </definition>
+
     <description xmlns="http://www.w3.org/1999/xhtml">
         <p>Defines a custom font to be used for text within the map.</p>
 
@@ -38,6 +49,13 @@
         generally a lot nicer! This time, you need to specify the size that the font
         should be rendered at. The size is in pixels. You can load the same font into
         multiple fontnumbers with different sizes to use in different parts of a map.</p>
+        
+        <p>The TrueType format takes an optional 4th component as a vertical offset
+        for all text rendered in this font.  Size is in whole-number pixels, relative
+        to the baseline of the font.  Negative numbers move the text down, positive
+        numbers move the text up.  This can be used to fine-tune text placement in
+        links, and other locations on the map.  It may, for example,  be used to render 
+        the BWLABEL text above or below a link arrow, instead of on top of it..</p>
 
         <p>The freetype library used in PHP makes a somewhat complex set of rules for
         where it will search for truetype fonts. The two easiest options are:

--- a/lib/WeatherMap.keywords.inc.php
+++ b/lib/WeatherMap.keywords.inc.php
@@ -6,6 +6,7 @@
 $WM_config_keywords2 = array(
     'GLOBAL' => array(
         'FONTDEFINE' => array(
+            array('GLOBAL', '/^\s*FONTDEFINE\s+(\d+)\s+(\S+)\s+(\d+)\s+(-?\d)\s*$/i','ReadConfig_Handle_FONTDEFINE'),
             array('GLOBAL', '/^\s*FONTDEFINE\s+(\d+)\s+(\S+)\s+(\d+)\s*$/i', 'ReadConfig_Handle_FONTDEFINE'),
             array('GLOBAL', '/^\s*FONTDEFINE\s+(\d+)\s+(\S+)\s*$/i', 'ReadConfig_Handle_FONTDEFINE'),
         ),

--- a/lib/Weathermap.class.php
+++ b/lib/Weathermap.class.php
@@ -1056,7 +1056,7 @@ class WeatherMap extends WeatherMapBase
 						$cx = $bounds[4] - $bounds[0];
 						$cy = $bounds[1] - $bounds[5];
 						if($cx > $xsize) $xsize = $cx;
-						$ysize += ($cy*1.2);
+						$ysize += ($cy*1.2) - $this->fonts[$fontnumber]->v_offset;  # subtract v_offset, due to coordinate system
 						# warn("Adding $cy (x was $cx)\n");
 					}
 					#$bounds=imagettfbbox($this->fonts[$fontnumber]->size, 0, $this->fonts[$fontnumber]->file,
@@ -2462,6 +2462,7 @@ function DrawTitle($im, $font, $colour)
 					$new_font->type = "truetype";
 					$new_font->file = $args[2];
 					$new_font->size = $args[3];
+					$new_font->v_offset = isset($args[4]) ? $args[4] : 0;
 					$this->fonts[$args[1]] = $new_font;
 				} else {
 					wm_warn("Failed to load ttf font " . $args[2]
@@ -3279,7 +3280,7 @@ function WriteConfig($filename)
 		if (count($this->fonts) > 0) {
 			foreach ($this->fonts as $fontnumber => $font) {
 				if ($font->type == 'truetype') {
-					$output .= sprintf("FONTDEFINE %d %s %d\n", $fontnumber, $font->file, $font->size);
+					$output .= sprintf("FONTDEFINE %d %s %d %d\n", $fontnumber, $font->file, $font->size, $font->v_offset);
 				}
 
 				if ($font->type == 'gd') {

--- a/weathermap
+++ b/weathermap
@@ -57,7 +57,8 @@ $args=$cg->readPHPArgv();
 
 $ret=$cg->getopt($args, $short_opts, $long_opts);
 
-if ((new PEAR)->isError($ret)) { die ("Error in command line: " . $ret->getMessage() . "\n (try --help)\n"); }
+$pear = new PEAR;
+if ($pear->isError($ret)) { die ("Error in command line: " . $ret->getMessage() . "\n (try --help)\n"); }
 
 $gopts=$ret[0];
 


### PR DESCRIPTION
This small patch adds a new attribute to defined fonts, allowing for a vertical offset anywhere a TrueType font is used.  The patch is against the 0.97-maintenance branch.

I have a number of links that have poor bounding boxes, and they display poorly in links, as shown in this example:
![screen shot 2016-07-13 at 12 44 42 pm](https://cloud.githubusercontent.com/assets/361383/16812201/187c7dea-48fa-11e6-9564-54d2ab033490.png)

However, with the patch, and adding a small offset, it looks much better, and works on angled text:
![screen shot 2016-07-13 at 12 49 15 pm](https://cloud.githubusercontent.com/assets/361383/16812270/4fe0e672-48fa-11e6-9023-35eca449f6c7.png) 
![screen shot 2016-07-13 at 3 55 22 pm](https://cloud.githubusercontent.com/assets/361383/16820009/f2c6f418-491c-11e6-9c90-e387b4e6611d.png)



Note that this can be (ab)used to allow for BWLABELs that are rendered above or below the link line, instead directly on top of it...similar to how BWLABELPOS can move the label to the left and right.  A quick example that shows the BWLABEL text rendered just "below" it's link:
![screen shot 2016-07-13 at 12 54 55 pm](https://cloud.githubusercontent.com/assets/361383/16812677/365ab974-48fc-11e6-8ca6-29efbd5dced9.png). 

In the configuration file, the offset is noted as a new, optional, element to `FONTDEFINE`.  To create the 2nd image (with less overhead whitespace):
```FONTDEFINE 200 docs/example/Vera 8 6```

Positive values move the text "up", while negative values move the text "down" (in the X,Y plane).

The 3rd image uses an offset in the other direction, plus a using existing BW* options:
```
FONTDEFINE 200 docs/example/Vera 8 -16
BWBOXCOLOR none
BWOUTLINECOLOR none
```
Unfortunately, the offset will depend entirely on the font used.  An offset of `6` looks good for this font (_Bitstream Vera Sans 8pt_), but other fonts have different baselines, and will need different values.  It also depends on the size of the font:  a pt size of 12 needs a different offset than a pt size of 8, for example.
