### PR TITLE
Fix string assert() calls which breaks PHP 7.2

### DIFF
--- a/lib/Weathermap/Core/Map.php
+++ b/lib/Weathermap/Core/Map.php
@@ -212,10 +212,10 @@ class Map extends MapBase
         $this->createDefaultLinks();
         $this->createDefaultNodes();
 
-        assert('is_object($this->nodes[":: DEFAULT ::"])');
-        assert('is_object($this->links[":: DEFAULT ::"])');
-        assert('is_object($this->nodes["DEFAULT"])');
-        assert('is_object($this->links["DEFAULT"])');
+        assert(is_object($this->nodes[":: DEFAULT ::"]));
+        assert(is_object($this->links[":: DEFAULT ::"]));
+        assert(is_object($this->nodes["DEFAULT"]));
+        assert(is_object($this->links["DEFAULT"]));
 
         $this->imap = new HTMLImagemap('weathermap');
 
@@ -432,7 +432,7 @@ class Map extends MapBase
         }
 
 //        $theItem = null;
-//        assert('is_scalar($input)');
+//        assert(is_scalar($input));
 
         $contextType = $this->getProcessStringContextName($context);
 

--- a/lib/Weathermap/Core/MapDataItem.php
+++ b/lib/Weathermap/Core/MapDataItem.php
@@ -138,7 +138,7 @@ class MapDataItem extends MapItem
     public function copyFrom(&$source)
     {
         MapUtility::debug("Initialising %s $this->name from $source->name\n", $this->myType());
-        assert('is_object($source)');
+        assert(is_object($source));
 
         foreach (array_keys($this->inheritedFieldList) as $fld) {
             if ($fld != 'template') {

--- a/lib/Weathermap/Core/MapNode.php
+++ b/lib/Weathermap/Core/MapNode.php
@@ -1059,8 +1059,8 @@ class MapNode extends MapDataItem
         $col1 = $this->colours[OUT];
         $col2 = $this->colours[IN];
 
-        assert('!is_null($col1)');
-        assert('!is_null($col2)');
+        assert(!is_null($col1));
+        assert(!is_null($col2));
 
         imagefilledarc(
             $iconImageRef,


### PR DESCRIPTION
This PR corrects issues with the assert() function requiring the passed assertion to be a boolean.  

Closes #144 